### PR TITLE
Backport descend_array + handling from rails config 1.0, with spec test.

### DIFF
--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -59,10 +59,28 @@ module RailsConfig
       reload!
     end
 
+    def descend_array(array)
+      array.length.times do |i|
+        value = array[i]
+        if value.instance_of? RailsConfig::Options
+          array[i] = value.to_hash
+        elsif value.instance_of? Array
+          array[i] = descend_array(value)
+        end
+      end
+      array
+    end
+
     def to_hash
       result = {}
       marshal_dump.each do |k, v|
-        result[k] = v.instance_of?(RailsConfig::Options) ? v.to_hash : v
+        if v.instance_of? RailsConfig::Options
+          result[k] = v.to_hash
+        elsif v.instance_of? Array
+          result[k] = descend_array(v)
+        else
+          result[k] = v
+        end
       end
       result
     end

--- a/spec/fixtures/array.yml
+++ b/spec/fixtures/array.yml
@@ -1,0 +1,7 @@
+nested:
+  -
+    foo: 'bar'
+    baz: 'bux'
+  -
+    foo: 'qar'
+    baz: 'qux'

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -51,6 +51,11 @@ describe RailsConfig do
     expect(config[:section][:servers]).to be_kind_of(Array)
   end
 
+  it "should convert recursively" do
+    config = RailsConfig.load_files("#{fixture_path}/array.yml").to_hash
+    expect(config[:nested]).to eql [{foo: 'bar', baz: 'bux'}, {foo: 'qar', baz: 'qux'}]
+  end
+
   it "should convert to a json" do
     config = RailsConfig.load_files("#{fixture_path}/development.yml").to_json
     expect(JSON.parse(config)["section"]["servers"]).to be_kind_of(Array)


### PR DESCRIPTION
This is just a minor backport to support some decisioning work that will end up with lists of hashes as configurations, e.g.:

``` yml
amount_adjustments:
  a:
    -
      min_amount: 0
      max_amount: 3000
      adjustment: -1
    -
      min_amount: 3001
      max_amount: 10000
      adjustment: 0
    -
      ...
```
